### PR TITLE
Remove metadata from watch page

### DIFF
--- a/braingrow-ai/src/WatchPage.css
+++ b/braingrow-ai/src/WatchPage.css
@@ -59,18 +59,6 @@
   margin: 0;
 }
 
-.video-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  color: #666;
-}
-
-.video-stats, .video-author {
-  display: flex;
-  gap: 15px;
-}
-
 .video-description {
   background: #f5f5f5;
   padding: 15px;

--- a/braingrow-ai/src/WatchPage.tsx
+++ b/braingrow-ai/src/WatchPage.tsx
@@ -73,19 +73,7 @@ export default function WatchPage() {
       
       <div className="video-info">
         <h1 className="video-title">{video.title}</h1>
-        
-        <div className="video-meta">
-          <div className="video-stats">
-            {video.views != null && <span className="views">👁️ {video.views.toString()} views</span>}
-            <span className="upload-date">📅 {video.date.toLocaleDateString()}</span>
-          </div>
-          
-          <div className="video-author">
-            {video.author != null && <span className="author">👤 {video.author}</span>}
-            <span className="category">🏷️ {video.category}</span>
-          </div>
-        </div>
-        
+
         <div className="video-description">
           <h3>Description</h3>
           <p>{video.description}</p>


### PR DESCRIPTION
## Summary
- Hide views, upload date, author, and category info on the watch page
- Drop unused watch page metadata styles

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: @typescript-eslint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a5abd9971883319c5f86b3332d9c63