### PR TITLE
Add AI chat to Watch page

### DIFF
--- a/braingrow-ai/src/WatchPage.css
+++ b/braingrow-ai/src/WatchPage.css
@@ -74,3 +74,80 @@
   border-radius: 4px;
   cursor: pointer;
 }
+
+.chat-button {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background-color: #2196f3;
+  color: white;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.chat-window {
+  position: fixed;
+  bottom: 90px;
+  right: 20px;
+  width: 300px;
+  max-height: 400px;
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
+  background-color: #2196f3;
+  color: white;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.chat-messages {
+  flex: 1;
+  padding: 10px;
+  overflow-y: auto;
+}
+
+.chat-message.user {
+  text-align: right;
+  color: #2196f3;
+  margin-bottom: 8px;
+}
+
+.chat-message.ai {
+  text-align: left;
+  color: #4caf50;
+  margin-bottom: 8px;
+}
+
+.chat-input {
+  display: flex;
+  gap: 5px;
+  padding: 10px;
+  border-top: 1px solid #ccc;
+}
+
+.chat-input input {
+  flex: 1;
+  padding: 5px;
+}
+
+.chat-input button {
+  padding: 5px 10px;
+  background-color: #2196f3;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/braingrow-ai/src/request.tsx
+++ b/braingrow-ai/src/request.tsx
@@ -127,6 +127,19 @@ export const getVideo = async (id: string): Promise<video> => {
   };
 };
 
+export const askVideoQuestion = async (id: string, question: string): Promise<string> => {
+  const response = await fetch(`${API_BASE}/api/videos/${encodeURIComponent(id)}/ask`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ question })
+  });
+  if (!response.ok) throw new Error('Ask AI failed');
+  const data = await response.json();
+  return data.answer;
+};
+
 export const signup = async (email: string, password: string, name: string): Promise<{ success: boolean; token?: string }> => {
   try {
     const response = await fetch('https://localhost:3000/api/signup', {


### PR DESCRIPTION
## Summary
- add askVideoQuestion API client for backend ask_AI endpoint
- add chat button and popup chat window on Watch page
- style chat interface with fixed-position button and window

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: MODULE_NOT_FOUND for rollup native module)*

------
https://chatgpt.com/codex/tasks/task_e_68a8379b0d808331a4068cfe6c7a9b9f