### PR TITLE
Add AI chat to Watch page

### DIFF
--- a/braingrow-ai/src/WatchPage.css
+++ b/braingrow-ai/src/WatchPage.css
@@ -45,6 +45,11 @@
 .video-title {
   font-size: 1.8rem;
   margin: 0;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .video-description {
@@ -95,13 +100,14 @@
   position: fixed;
   bottom: 90px;
   right: 20px;
-  width: 300px;
+  width: min(90vw, 300px);
   max-height: 400px;
   background: white;
   border: 1px solid #ccc;
   border-radius: 8px;
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
 }
 
 .chat-header {
@@ -143,6 +149,7 @@
 .time-range input {
   flex: 1;
   padding: 5px;
+  box-sizing: border-box;
 }
 
 .chat-input {
@@ -154,6 +161,7 @@
 .chat-input input {
   flex: 1;
   padding: 5px;
+  box-sizing: border-box;
 }
 
 .chat-input button {

--- a/braingrow-ai/src/WatchPage.css
+++ b/braingrow-ai/src/WatchPage.css
@@ -141,15 +141,20 @@
 
 .time-range {
   display: flex;
-  gap: 5px;
+  flex-direction: column;
   padding: 10px;
   border-top: 1px solid #ccc;
+  gap: 5px;
 }
 
-.time-range input {
-  flex: 1;
-  padding: 5px;
-  box-sizing: border-box;
+.time-range input[type="range"] {
+  width: 100%;
+}
+
+.time-range .time-values {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
 }
 
 .chat-input {

--- a/braingrow-ai/src/WatchPage.css
+++ b/braingrow-ai/src/WatchPage.css
@@ -36,6 +36,12 @@
   gap: 15px;
 }
 
+.video-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .video-title {
   font-size: 1.8rem;
   margin: 0;
@@ -68,6 +74,90 @@
 
 .comment-submit {
   padding: 10px 20px;
+  background-color: #2196f3;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.chat-button {
+  margin-left: 10px;
+  padding: 5px 10px;
+  background-color: #2196f3;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.chat-window {
+  position: fixed;
+  bottom: 90px;
+  right: 20px;
+  width: 300px;
+  max-height: 400px;
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
+  background-color: #2196f3;
+  color: white;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.chat-messages {
+  flex: 1;
+  padding: 10px;
+  overflow-y: auto;
+}
+
+.chat-message.user {
+  text-align: right;
+  color: #2196f3;
+  margin-bottom: 8px;
+}
+
+.chat-message.ai {
+  text-align: left;
+  color: #4caf50;
+  margin-bottom: 8px;
+}
+
+.time-range {
+  display: flex;
+  gap: 5px;
+  padding: 10px;
+  border-top: 1px solid #ccc;
+}
+
+.time-range input {
+  flex: 1;
+  padding: 5px;
+}
+
+.chat-input {
+  display: flex;
+  gap: 5px;
+  padding: 10px;
+}
+
+.chat-input input {
+  flex: 1;
+  padding: 5px;
+}
+
+.chat-input button {
+  padding: 5px 10px;
   background-color: #2196f3;
   color: white;
   border: none;

--- a/braingrow-ai/src/WatchPage.css
+++ b/braingrow-ai/src/WatchPage.css
@@ -147,8 +147,55 @@
   gap: 5px;
 }
 
-.time-range input[type="range"] {
+.time-range .range-inputs {
+  position: relative;
+  height: 30px;
+}
+
+.time-range .range-inputs input[type="range"] {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
+  margin: 0;
+  pointer-events: none;
+  -webkit-appearance: none;
+  background: none;
+}
+
+.time-range .range-inputs input[type="range"]::-webkit-slider-thumb {
+  pointer-events: all;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #2196f3;
+  border: none;
+}
+
+.time-range .range-inputs input[type="range"]::-moz-range-thumb {
+  pointer-events: all;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #2196f3;
+  border: none;
+}
+
+.time-range .range-inputs input[type="range"]::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 2px;
+  background: #ccc;
+}
+
+.time-range .range-inputs input[type="range"]::-moz-range-track {
+  height: 4px;
+  border-radius: 2px;
+  background: #ccc;
+}
+
+.time-range .range-inputs input[type="range"].range-start::-webkit-slider-runnable-track,
+.time-range .range-inputs input[type="range"].range-start::-moz-range-track {
+  background: none;
 }
 
 .time-range .time-values {

--- a/braingrow-ai/src/WatchPage.tsx
+++ b/braingrow-ai/src/WatchPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { video } from './structures/video';
-import { getVideo } from './request'; // Ensure this function is defined in your request.tsx
+import { getVideo, askVideoQuestion } from './request';
 import './WatchPage.css';
 
 export default function WatchPage() {
@@ -10,6 +10,12 @@ export default function WatchPage() {
   const [video, setVideo] = useState<video | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [videoError, setVideoError] = useState<string | null>(null); // Add error state
+  const [chatOpen, setChatOpen] = useState(false);
+  const [messages, setMessages] = useState<{ sender: 'user' | 'ai'; text: string }[]>([]);
+  const [question, setQuestion] = useState('');
+  const [isAsking, setIsAsking] = useState(false);
+  const [startTime, setStartTime] = useState('');
+  const [endTime, setEndTime] = useState('');
 
   useEffect(() => {
     // Reset state when component mounts or id changes
@@ -44,6 +50,28 @@ export default function WatchPage() {
   if (!video) return <div>Video not found</div>;
   if (!video.url) return <div>Invalid video source - no URL provided</div>;
 
+  const handleSend = async () => {
+    if (!id || !question.trim()) return;
+    const userMessage = { sender: 'user' as const, text: question };
+    setMessages((prev) => [...prev, userMessage]);
+    setQuestion('');
+    setIsAsking(true);
+    try {
+      const answer = await askVideoQuestion(
+        id,
+        userMessage.text,
+        startTime ? Number(startTime) : undefined,
+        endTime ? Number(endTime) : undefined
+      );
+      setMessages((prev) => [...prev, { sender: 'ai', text: answer }]);
+    } catch (err) {
+      console.error(err);
+      setMessages((prev) => [...prev, { sender: 'ai', text: 'Failed to get response' }]);
+    } finally {
+      setIsAsking(false);
+    }
+  };
+
   return (
     <div className="watch-container">
       <div className="video-player-container">
@@ -64,7 +92,14 @@ export default function WatchPage() {
       </div>
 
       <div className="video-info">
-        <h1 className="video-title">{video.title}</h1>
+        <div className="video-header">
+          <h1 className="video-title">{video.title}</h1>
+          {!chatOpen && (
+            <button className="chat-button" onClick={() => setChatOpen(true)}>
+              Chat
+            </button>
+          )}
+        </div>
 
         <div className="video-description">
           <h3>Description</h3>
@@ -82,6 +117,51 @@ export default function WatchPage() {
           </div>
         </div>
       </div>
+
+      {chatOpen && (
+        <div className="chat-window">
+          <div className="chat-header">
+            <span>Ask AI</span>
+            <button onClick={() => setChatOpen(false)}>×</button>
+          </div>
+          <div className="chat-messages">
+            {messages.map((m, i) => (
+              <div key={i} className={`chat-message ${m.sender}`}>
+                {m.text}
+              </div>
+            ))}
+          </div>
+          <div className="time-range">
+            <input
+              type="number"
+              min="0"
+              value={startTime}
+              onChange={(e) => setStartTime(e.target.value)}
+              placeholder="Start (s)"
+              disabled={isAsking}
+            />
+            <input
+              type="number"
+              min="0"
+              value={endTime}
+              onChange={(e) => setEndTime(e.target.value)}
+              placeholder="End (s)"
+              disabled={isAsking}
+            />
+          </div>
+          <div className="chat-input">
+            <input
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              placeholder="Ask a question..."
+              disabled={isAsking}
+            />
+            <button onClick={handleSend} disabled={isAsking || !question.trim()}>
+              Send
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/braingrow-ai/src/WatchPage.tsx
+++ b/braingrow-ai/src/WatchPage.tsx
@@ -18,6 +18,18 @@ export default function WatchPage() {
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(0);
 
+  const handleStartChange = (value: number) => {
+    setStartTime(Math.min(value, endTime));
+  };
+
+  const handleEndChange = (value: number) => {
+    setEndTime(Math.max(value, startTime));
+  };
+
+  const startPercent = duration ? (startTime / duration) * 100 : 0;
+  const endPercent = duration ? (endTime / duration) * 100 : 0;
+  const trackBackground = `linear-gradient(to right, #ccc ${startPercent}%, #2196f3 ${startPercent}%, #2196f3 ${endPercent}%, #ccc ${endPercent}%)`;
+
   useEffect(() => {
     // Reset state when component mounts or id changes
     setVideo(null);
@@ -138,22 +150,27 @@ export default function WatchPage() {
             ))}
           </div>
           <div className="time-range">
-            <input
-              type="range"
-              min={0}
-              max={endTime}
-              value={startTime}
-              onChange={(e) => setStartTime(Number(e.target.value))}
-              disabled={isAsking}
-            />
-            <input
-              type="range"
-              min={startTime}
-              max={duration}
-              value={endTime}
-              onChange={(e) => setEndTime(Number(e.target.value))}
-              disabled={isAsking}
-            />
+            <div className="range-inputs">
+              <input
+                type="range"
+                min={0}
+                max={duration}
+                value={endTime}
+                onChange={(e) => handleEndChange(Number(e.target.value))}
+                disabled={isAsking}
+                className="range-end"
+                style={{ background: trackBackground }}
+              />
+              <input
+                type="range"
+                min={0}
+                max={duration}
+                value={startTime}
+                onChange={(e) => handleStartChange(Number(e.target.value))}
+                disabled={isAsking}
+                className="range-start"
+              />
+            </div>
             <div className="time-values">
               <span>{startTime}s</span>
               <span>{endTime}s</span>

--- a/braingrow-ai/src/WatchPage.tsx
+++ b/braingrow-ai/src/WatchPage.tsx
@@ -14,8 +14,9 @@ export default function WatchPage() {
   const [messages, setMessages] = useState<{ sender: 'user' | 'ai'; text: string }[]>([]);
   const [question, setQuestion] = useState('');
   const [isAsking, setIsAsking] = useState(false);
-  const [startTime, setStartTime] = useState('');
-  const [endTime, setEndTime] = useState('');
+  const [duration, setDuration] = useState(0);
+  const [startTime, setStartTime] = useState(0);
+  const [endTime, setEndTime] = useState(0);
 
   useEffect(() => {
     // Reset state when component mounts or id changes
@@ -60,8 +61,8 @@ export default function WatchPage() {
       const answer = await askVideoQuestion(
         id,
         userMessage.text,
-        startTime ? Number(startTime) : undefined,
-        endTime ? Number(endTime) : undefined
+        startTime,
+        endTime
       );
       setMessages((prev) => [...prev, { sender: 'ai', text: answer }]);
     } catch (err) {
@@ -80,6 +81,11 @@ export default function WatchPage() {
             controls
             src={video.url}
             poster={video.coverUrl}
+            onLoadedMetadata={(e) => {
+              const dur = Math.floor(e.currentTarget.duration);
+              setDuration(dur);
+              setEndTime(dur);
+            }}
             onError={(e) => {
               const videoElement = e.target as HTMLVideoElement;
               const errorDetails = videoElement.error ? ` (Code: ${videoElement.error.code}, Message: ${videoElement.error.message})` : '';
@@ -133,21 +139,25 @@ export default function WatchPage() {
           </div>
           <div className="time-range">
             <input
-              type="number"
-              min="0"
+              type="range"
+              min={0}
+              max={endTime}
               value={startTime}
-              onChange={(e) => setStartTime(e.target.value)}
-              placeholder="Start (s)"
+              onChange={(e) => setStartTime(Number(e.target.value))}
               disabled={isAsking}
             />
             <input
-              type="number"
-              min="0"
+              type="range"
+              min={startTime}
+              max={duration}
               value={endTime}
-              onChange={(e) => setEndTime(e.target.value)}
-              placeholder="End (s)"
+              onChange={(e) => setEndTime(Number(e.target.value))}
               disabled={isAsking}
             />
+            <div className="time-values">
+              <span>{startTime}s</span>
+              <span>{endTime}s</span>
+            </div>
           </div>
           <div className="chat-input">
             <input

--- a/braingrow-ai/src/request.tsx
+++ b/braingrow-ai/src/request.tsx
@@ -127,6 +127,27 @@ export const getVideo = async (id: string): Promise<video> => {
   };
 };
 
+export const askVideoQuestion = async (
+  id: string,
+  question: string,
+  startTime?: number,
+  endTime?: number
+): Promise<string> => {
+  const body: Record<string, unknown> = { question };
+  if (typeof startTime === 'number') body.startTime = startTime;
+  if (typeof endTime === 'number') body.endTime = endTime;
+  const response = await fetch(`${API_BASE}/api/videos/${encodeURIComponent(id)}/ask`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  });
+  if (!response.ok) throw new Error('Ask AI failed');
+  const data = await response.json();
+  return data.answer;
+};
+
 export const signup = async (email: string, password: string, name: string): Promise<{ success: boolean; token?: string }> => {
   try {
     const response = await fetch('https://localhost:3000/api/signup', {


### PR DESCRIPTION
## Summary
- add askVideoQuestion API client for backend ask_AI endpoint with optional time range
- add chat button beside video title with popup chat window for AI Q&A
- allow selecting start and end times for questions and style new inputs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68a8379b0d808331a4068cfe6c7a9b9f