### PR TITLE
feat: integrate Vertex AI video recognition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.db3
 *.bak
 *.sql
+*.pyc
 instance/
 __pycache__/
 .env

--- a/braingrow-ai-backend/app.py
+++ b/braingrow-ai-backend/app.py
@@ -5,7 +5,12 @@ import jwt
 import datetime
 import traceback
 from functools import wraps
-from video_handler import extract_yt_url, ask_AI, recognize_video
+from video_handler import (
+    extract_yt_url,
+    ask_AI,
+    recognize_video,
+    VertexAICredentialsError,
+)
 from sqlalchemy import inspect, text
 
 # Import everything from the consolidated models file
@@ -358,6 +363,9 @@ def ask_video_question(video_id):
             'question': question,
             'answer': ask_AI(video.url, question)
         })
+    except VertexAICredentialsError as e:
+        print(f"Vertex AI credentials error: {str(e)}")
+        return jsonify({'error': str(e), 'code': 'NO_CREDENTIALS'}), 500
     except Exception as e:
         print(f"Error in asking video question: {str(e)}")
         return jsonify({'error': str(e)}), 500
@@ -371,6 +379,9 @@ def recognize_video_route(video_id):
             return jsonify({'error': 'Video not found'}), 404
         description = recognize_video(video.url)
         return jsonify({'description': description})
+    except VertexAICredentialsError as e:
+        print(f"Vertex AI credentials error: {str(e)}")
+        return jsonify({'error': str(e), 'code': 'NO_CREDENTIALS'}), 500
     except Exception as e:
         print(f"Error in video recognition: {str(e)}")
         return jsonify({'error': str(e)}), 500

--- a/braingrow-ai-backend/video_handler.py
+++ b/braingrow-ai-backend/video_handler.py
@@ -4,6 +4,11 @@ import mimetypes
 import vertexai
 from vertexai.preview.generative_models import GenerativeModel, Part
 from os import path
+from google.auth.exceptions import DefaultCredentialsError
+
+
+class VertexAICredentialsError(RuntimeError):
+    """Raised when Google credentials are missing."""
 
 ydl_opts = {
     'format': 'best',
@@ -18,7 +23,13 @@ def extract_yt_url(url):
 def _init_vertex_ai(project_id: str | None = None, location: str = "us-central1"):
     project_id = "braingrowai"
     location = os.getenv("australia-southeast2", location)
-    vertexai.init(project=project_id, location=location)
+    try:
+        vertexai.init(project=project_id, location=location)
+    except DefaultCredentialsError as exc:
+        raise VertexAICredentialsError(
+            "Google Application Default Credentials not found. "
+            "Set up credentials by following https://cloud.google.com/docs/authentication/external/set-up-adc"
+        ) from exc
 
 
 def _get_mime_type(url: str) -> str:

--- a/braingrow-ai/src/WatchPage.tsx
+++ b/braingrow-ai/src/WatchPage.tsx
@@ -67,7 +67,11 @@ export default function WatchPage() {
           setMessages((prev) => [...prev, { sender: 'ai', text: description }]);
           setHasRecognized(true);
         })
-        .catch((err) => console.error('Error recognizing video:', err));
+        .catch((err) => {
+          console.error('Error recognizing video:', err);
+          const msg = err instanceof Error ? err.message : 'Failed to summarize video';
+          setMessages((prev) => [...prev, { sender: 'ai', text: msg }]);
+        });
     }
   }, [chatOpen, id, hasRecognized]);
 
@@ -100,7 +104,8 @@ export default function WatchPage() {
       setMessages((prev) => [...prev, { sender: 'ai', text: answer }]);
     } catch (err) {
       console.error(err);
-      setMessages((prev) => [...prev, { sender: 'ai', text: 'Failed to get response' }]);
+      const msg = err instanceof Error ? err.message : 'Failed to get response';
+      setMessages((prev) => [...prev, { sender: 'ai', text: msg }]);
     } finally {
       setIsAsking(false);
     }

--- a/braingrow-ai/src/request.tsx
+++ b/braingrow-ai/src/request.tsx
@@ -129,8 +129,8 @@ export const getVideo = async (id: string): Promise<video> => {
 
 export const recognizeVideo = async (id: string): Promise<string> => {
   const response = await fetch(`${API_BASE}/api/videos/${encodeURIComponent(id)}/recognize`);
-  if (!response.ok) throw new Error('Video recognition failed');
-  const data = await response.json();
+  const data = await response.json().catch(() => undefined);
+  if (!response.ok) throw new Error(data?.error || 'Video recognition failed');
   return data.description;
 };
 
@@ -150,8 +150,8 @@ export const askVideoQuestion = async (
     },
     body: JSON.stringify(body)
   });
-  if (!response.ok) throw new Error('Ask AI failed');
-  const data = await response.json();
+  const data = await response.json().catch(() => undefined);
+  if (!response.ok) throw new Error(data?.error || 'Ask AI failed');
   return data.answer;
 };
 


### PR DESCRIPTION
## Summary
- add video recognition request helper
- show Vertex AI video summary when chat opens on watch page
- display chat button when video enters fullscreen
- fix Vertex AI video handling by using `uri` parameter and MIME type detection
- handle missing Google credentials gracefully with clearer API errors

## Testing
- `npm run lint`
- `node node_modules/typescript/bin/tsc -b --diagnostics`
- `node node_modules/vite/bin/vite.js build`
- `python -m py_compile app.py video_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68aba5a55a488331bea6a9e5a23f08c9