### PR TITLE
feat: add signup page

### DIFF
--- a/braingrow-ai/src/App.tsx
+++ b/braingrow-ai/src/App.tsx
@@ -5,6 +5,7 @@ import Footer from './structures/Footer';
 import { HomePage } from './HomePage';
 import SearchPage from './SearchPage';
 import LoginPage from './LoginPage';
+import SignUpPage from './SignUpPage';
 import WatchPage from './WatchPage';
 import ProfilePage from './ProfilePage';
 
@@ -17,6 +18,7 @@ function App() {
           <Route path="/" element={<HomePage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/signup" element={<SignUpPage />} />
           <Route path="/watch/:id" element={<WatchPage />} />
           <Route path="/profile" element={<ProfilePage />} />
         </Routes>

--- a/braingrow-ai/src/SignUpPage.css
+++ b/braingrow-ai/src/SignUpPage.css
@@ -1,0 +1,159 @@
+.signup-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.signup-container {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+  background-color: #f5f5f5;
+}
+
+.signup-card {
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 32px;
+  width: 100%;
+  max-width: 400px;
+}
+
+.signup-title {
+  text-align: center;
+  margin-bottom: 24px;
+  color: #333;
+  font-size: 24px;
+}
+
+.signup-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #555;
+}
+
+.form-input {
+  padding: 10px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  height: 36px;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: #1890ff;
+  box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.2);
+}
+
+.error-message {
+  color: #ff4d4f;
+  font-size: 14px;
+  padding: 8px;
+  background-color: #fff1f0;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.form-actions {
+  margin-top: 16px;
+}
+
+.signup-button {
+  width: 100%;
+  padding: 8px 16px;
+  font-size: 14px;
+  line-height: 1.5;
+  height: 36px;
+  background-color: #1890ff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.2s;
+}
+
+.signup-button:hover:not(:disabled) {
+  background-color: #40a9ff;
+}
+
+.signup-button:disabled {
+  background-color: #8cc8ff;
+  cursor: not-allowed;
+}
+
+/* Modal styles for signup errors */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-dialog {
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 24px;
+  width: 100%;
+  max-width: 400px;
+}
+
+.modal-title {
+  margin-top: 0;
+  margin-bottom: 16px;
+  color: #ff4d4f;
+  font-size: 18px;
+  font-weight: 500;
+}
+
+.modal-message {
+  margin-bottom: 24px;
+  color: #555;
+  line-height: 1.5;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.modal-button {
+  padding: 8px 16px;
+  font-size: 14px;
+  line-height: 1.5;
+  height: 36px;
+  background-color: #1890ff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.2s;
+}
+
+.modal-button:hover {
+  background-color: #40a9ff;
+}

--- a/braingrow-ai/src/SignUpPage.tsx
+++ b/braingrow-ai/src/SignUpPage.tsx
@@ -1,0 +1,148 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { signup } from './request';
+import './SignUpPage.css';
+
+const SignUpPage: React.FC = () => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [showErrorModal, setShowErrorModal] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorMessage('');
+    setLoading(true);
+
+    try {
+      if (!name || !email || !password || !confirmPassword) {
+        setErrorMessage('Please fill in all fields');
+        setShowErrorModal(true);
+        return;
+      }
+
+      if (!email.includes('@')) {
+        setErrorMessage('Please enter a valid email');
+        setShowErrorModal(true);
+        return;
+      }
+
+      if (password !== confirmPassword) {
+        setErrorMessage('Passwords do not match');
+        setShowErrorModal(true);
+        return;
+      }
+
+      const result = await signup(email, password, name);
+      if (result.success) {
+        navigate('/');
+      } else {
+        setErrorMessage('Signup failed. Please try again.');
+        setShowErrorModal(true);
+      }
+    } catch (err) {
+      console.error(err);
+      setErrorMessage('An error occurred during signup');
+      setShowErrorModal(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="signup-page">
+      <main className="signup-container">
+        <div className="signup-card">
+          <h1 className="signup-title">Sign Up for BrainGrow AI</h1>
+
+          <form onSubmit={handleSubmit} className="signup-form">
+            <div className="form-group">
+              <label htmlFor="name" className="form-label">Name</label>
+              <input
+                type="text"
+                id="name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="form-input"
+                placeholder="Your name"
+                disabled={loading}
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="email" className="form-label">Email</label>
+              <input
+                type="email"
+                id="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="form-input"
+                placeholder="your.email@example.com"
+                disabled={loading}
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="password" className="form-label">Password</label>
+              <input
+                type="password"
+                id="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="form-input"
+                placeholder="Enter your password"
+                disabled={loading}
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="confirmPassword" className="form-label">Confirm Password</label>
+              <input
+                type="password"
+                id="confirmPassword"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className="form-input"
+                placeholder="Confirm your password"
+                disabled={loading}
+              />
+            </div>
+
+            <div className="form-actions">
+              <button
+                type="submit"
+                className="signup-button"
+                disabled={loading}
+              >
+                {loading ? 'Signing up...' : 'Sign Up'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </main>
+
+      {showErrorModal && (
+        <div className="modal-overlay">
+          <div className="modal-dialog">
+            <h3 className="modal-title">Signup Failed</h3>
+            <p className="modal-message">{errorMessage}</p>
+            <div className="modal-actions">
+              <button
+                className="modal-button"
+                onClick={() => setShowErrorModal(false)}
+              >
+                OK
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SignUpPage;

--- a/braingrow-ai/src/request.tsx
+++ b/braingrow-ai/src/request.tsx
@@ -148,9 +148,13 @@ export const askVideoQuestion = async (
   return data.answer;
 };
 
-export const signup = async (email: string, password: string, name: string): Promise<{ success: boolean; token?: string }> => {
+export const signup = async (
+  email: string,
+  password: string,
+  name: string
+): Promise<{ success: boolean; token?: string }> => {
   try {
-    const response = await fetch('https://localhost:3000/api/signup', {
+    const response = await fetch(`${API_BASE}/api/signup`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/braingrow-ai/src/structures/Header.tsx
+++ b/braingrow-ai/src/structures/Header.tsx
@@ -67,7 +67,7 @@ const Header: React.FC = () => {
             <button className="login-button" onClick={() => navigate('/login')}>
               Login
             </button>
-            <button className="signup-button">
+            <button className="signup-button" onClick={() => navigate('/signup')}>
               Sign Up
             </button>
           </>


### PR DESCRIPTION
## Summary
- add `SignUpPage` component with form inputs for name, email, and password confirmation
- wire up signup API call and navigation from header
- register signup route in main app

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae8089a3b88331845795c67bf6bcd6