### PR TITLE
Display user tendency on profile page

### DIFF
--- a/braingrow-ai/src/ProfilePage.css
+++ b/braingrow-ai/src/ProfilePage.css
@@ -42,6 +42,12 @@
   margin: 0 0 0.25rem 0;
 }
 
+.profile-tendency {
+  font-size: 1.1rem;
+  color: #666;
+  margin: 0 0 0.25rem 0;
+}
+
 .profile-join-date {
   font-size: 0.9rem;
   color: #999;

--- a/braingrow-ai/src/ProfilePage.tsx
+++ b/braingrow-ai/src/ProfilePage.tsx
@@ -36,6 +36,7 @@ const ProfilePage: React.FC = () => {
         <div className="profile-info">
           <h1 className="profile-name">{userData.username}</h1>
           <p className="profile-email">{userData.email}</p>
+          <p className="profile-tendency">Current tendency: {userData.tendency || 'Not specified'}</p>
           {userData.session_info?.login_time && (
             <p className="profile-join-date">
               Logged in {new Date(userData.session_info.login_time).toLocaleString()}


### PR DESCRIPTION
## Summary
- Show the user's current learning tendency in profile info
- Style the tendency text to match existing profile elements

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68aee739ef0c8331844bf7fa0b6b7bf6