### PR TITLE
Limit AI response tokens for faster answers

### DIFF
--- a/braingrow-ai-backend/video_handler.py
+++ b/braingrow-ai-backend/video_handler.py
@@ -34,7 +34,8 @@ def ask_AI(video_url, question, start = -1, end = -1):
   generate_content_config = types.GenerateContentConfig(
     temperature = 1,
     top_p = 0.95,
-    max_output_tokens = 65535,
+    # Reduce the number of tokens the model may generate to speed up responses
+    max_output_tokens = 1024,
     safety_settings = [types.SafetySetting(
       category="HARM_CATEGORY_HATE_SPEECH",
       threshold="OFF"


### PR DESCRIPTION
## Summary
- limit Gemini model output to 1024 tokens to cut response latency

## Testing
- `python -m py_compile braingrow-ai-backend/video_handler.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3aed339408331ab725adfbb2a9bd8