### PR TITLE
chore: add GitHub Pages deployment

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy Frontend to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: braingrow-ai/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: braingrow-ai
+      - name: Build
+        run: npm run build
+        working-directory: braingrow-ai
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: braingrow-ai/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/braingrow-ai/src/main.tsx
+++ b/braingrow-ai/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';


### PR DESCRIPTION
## Summary
- add workflow to deploy frontend to GitHub Pages
- clean up unused React import in frontend entry point

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3b078fa3c8331a2e88177bf3fc2c7