### PR TITLE
Fix header auth button widths to avoid search bar overlap

### DIFF
--- a/braingrow-ai/src/structures/Header.css
+++ b/braingrow-ai/src/structures/Header.css
@@ -132,8 +132,9 @@
   gap: 0.75rem;
 }
 
-.header-login-button {
-  width: 100px;
+.header-login-button,
+.header-signup-button {
+  width: auto; /* allow buttons to size naturally */
   padding: 0.5rem 1rem;
   border-radius: 8px;
   border: none;
@@ -142,18 +143,7 @@
   font-size: 14px;
   cursor: pointer;
   transition: all 0.2s;
-}
-
-.header-signup-button {
-  width: 100px;
-  padding: 0.1rem 0.1rem;
-  border-radius: 8px;
-  border: none;
-  background-color: #1a73e8;
-  color: #ffffff;
-  font-size: 14px;
-  cursor: pointer;
-  transition: all 0.2s;
+  flex-shrink: 0; /* prevent shrinking into search bar */
 }
 
 .profile-button {


### PR DESCRIPTION
## Summary
- allow header login and sign-up buttons to size naturally without fixed widths
- prevent auth buttons from shrinking into search bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `node node_modules/eslint/bin/eslint.js .` *(fails: `/workspace/BraingrowAI/braingrow-ai/src/WatchPage.tsx` 24:19 error Unnecessary escape character: \"; 44:11 error 'withPlaceholders' is never reassigned. Use 'const' instead)*

------
https://chatgpt.com/codex/tasks/task_e_68b7665ad868833184e33f4aeb4954f3