### PR TITLE
Use search icon only in header

### DIFF
--- a/braingrow-ai/src/structures/Header.css
+++ b/braingrow-ai/src/structures/Header.css
@@ -36,7 +36,7 @@
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: center;
 }
 
 .header .search-button .search-icon {

--- a/braingrow-ai/src/structures/Header.tsx
+++ b/braingrow-ai/src/structures/Header.tsx
@@ -45,9 +45,12 @@ const Header: React.FC = () => {
             onChange={(e) => setSearchQuery(e.target.value)}
             className="search-input"
           />
-          <button type="submit" className="search-button">
+          <button
+            type="submit"
+            className="search-button"
+            aria-label="Search"
+          >
             <FaSearch size={16} className="search-icon" />
-            <span className="search-button-text">Search</span>
           </button>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- remove "Search" text from header search button, leaving only the icon with an accessible label
- center search icon by adjusting button styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npx eslint src/structures/Header.tsx && echo 'Lint passed'`

------
https://chatgpt.com/codex/tasks/task_e_68b768cb4a908331a24d4ca0e78d5e20