### PR TITLE
fix: isolate header sign-up button styles

### DIFF
--- a/braingrow-ai/src/structures/Header.css
+++ b/braingrow-ai/src/structures/Header.css
@@ -130,7 +130,7 @@
   transition: all 0.2s;
 }
 
-.signup-button {
+.header-signup-button {
   width: 150px;
   padding: 0.5rem 1rem;
   border-radius: 8px;
@@ -140,6 +140,8 @@
   font-size: 14px;
   cursor: pointer;
   transition: all 0.2s;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .profile-button {

--- a/braingrow-ai/src/structures/Header.tsx
+++ b/braingrow-ai/src/structures/Header.tsx
@@ -67,7 +67,7 @@ const Header: React.FC = () => {
             <button className="login-button" onClick={() => navigate('/login')}>
               Login
             </button>
-            <button className="signup-button" onClick={() => navigate('/signup')}>
+            <button className="header-signup-button" onClick={() => navigate('/signup')}>
               Sign Up
             </button>
           </>


### PR DESCRIPTION
## Summary
- rename sign-up button class in header to avoid style conflicts
- keep header sign-up text on a single line with fixed width

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b53d4271748331988e058dd28964f0